### PR TITLE
[FEATURE] Support rendering of WebP and JPEG images

### DIFF
--- a/Classes/Service/AdmiralCloudService.php
+++ b/Classes/Service/AdmiralCloudService.php
@@ -478,11 +478,17 @@ class AdmiralCloudService implements SingletonInterface
             // With crop information
             $cropData = json_decode((string)$file->getTxAdmiralCloudConnectorCrop()) or $cropData = json_decode('{"usePNG": "false"}');
 
+            if (property_exists($cropData, 'usePNG') && $cropData->usePNG === 'true') {
+                $imageOutputFormat = 'png';
+            } else {
+                $imageOutputFormat = ImageUtility::getDefaultImageOutputFormat();
+            }
+
             return \sprintf(
                 '%sv5/deliverEmbed/%s/image%s/cropperjsfocus/%s/%s/%s?poc=true%s%s',
                 ConfigurationUtility::getSmartcropUrl(),
                 $token ? $token['hash'] : $file->getTxAdmiralCloudConnectorLinkhash(),
-                property_exists($cropData, 'usePNG') && $cropData->usePNG === 'true' ? '_png' : '',
+                $imageOutputFormat !== '' ? '_' . $imageOutputFormat : '',
                 $dimensions->width,
                 $dimensions->height,
                 $file->getTxAdmiralCloudConnectorCropUrlPath(),
@@ -575,7 +581,7 @@ class AdmiralCloudService implements SingletonInterface
         // Link is required for AdmiralCloud field
         if (!$linkHash) {
             throw new InvalidFileConfigurationException(
-                'Any valid hash was found for file in mediaContainer given configuration: ' . json_encode($mediaContainer),
+                'No valid hash was found for file in mediaContainer given configuration: ' . json_encode($mediaContainer),
                 111222444578,
             );
         }

--- a/Classes/Utility/ImageUtility.php
+++ b/Classes/Utility/ImageUtility.php
@@ -21,6 +21,12 @@ use TYPO3\CMS\Core\Resource\FileInterface;
 
 final readonly class ImageUtility
 {
+    private const SUPPORTED_FORMATS = [
+        'webp',
+        'jpeg',
+        'png',
+    ];
+
     /**
      * Calculate dimension based on image ratio and cropped data
      *
@@ -138,5 +144,17 @@ final readonly class ImageUtility
         }
 
         return json_decode($crop) ?: null;
+    }
+
+    public static function getDefaultImageOutputFormat(): string
+    {
+        $envFormat = getenv('ADMIRALCLOUD_DEFAULT_IMAGE_OUTPUT_FORMAT');
+
+        if (in_array($envFormat, self::SUPPORTED_FORMATS, true)) {
+            return $envFormat;
+        }
+
+        // Use PNG as default (this may change in the future)
+        return 'png';
     }
 }

--- a/Classes/ViewHelpers/ImageViewHelper.php
+++ b/Classes/ViewHelpers/ImageViewHelper.php
@@ -113,7 +113,7 @@ final class ImageViewHelper extends AbstractTagBasedViewHelper
 
             // Inject focus point values as data attributes
             if ($this->arguments['showFocus'] && $crop !== '') {
-                $cropConfiguration = json_decode($crop, true);
+                $cropConfiguration = json_decode((string)$crop, true);
 
                 if (isset($cropConfiguration['focusPoint']['x'], $cropConfiguration['focusPoint']['y'])) {
                     $this->tag->addAttribute('data-focus-x', $cropConfiguration['focusPoint']['x']);

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ putenv('ADMIRALCLOUD_DOCUMENT_CONFIG_ID=240');
 putenv('ADMIRALCLOUD_AUDIO_CONFIG_ID=241');
 putenv('ADMIRALCLOUD_FLAG_CONFIG_ID=10');
 putenv('ADMIRALCLOUD_IFRAMEURL=https://t3intpoc.admiralcloud.com/');
+putenv('ADMIRALCLOUD_DEFAULT_IMAGE_OUTPUT_FORMAT=webp'); // webp | jpeg | png
 
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['admiral_cloud_connector'] = [
     'frontend' => \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class,


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is built upon the [feature/typo3-v13](https://github.com/CPS-IT/admiral-cloud-connector/tree/feature/typo3-v13) branch.

---

This PR adds support for WebP and JPEG images. The appropriate image format can be set by using the environment variable `ADMIRALCLOUD_DEFAULT_IMAGE_OUTPUT_FORMAT`.

Example:

```dotenv
# Render WebP images
ADMIRALCLOUD_DEFAULT_IMAGE_OUTPUT_FORMAT=webp

# Render JPEG images
ADMIRALCLOUD_DEFAULT_IMAGE_OUTPUT_FORMAT=jpeg

# Render PNG images (default)
ADMIRALCLOUD_DEFAULT_IMAGE_OUTPUT_FORMAT=png
```