### PR TITLE
[BUGFIX] Fix bug in getMediaType with types in TYPO3 v13

### DIFF
--- a/Classes/Service/AdmiralCloudService.php
+++ b/Classes/Service/AdmiralCloudService.php
@@ -93,7 +93,7 @@ class AdmiralCloudService implements SingletonInterface
             FileType::IMAGE => 'image',
             FileType::AUDIO => 'audio',
             FileType::VIDEO => 'video',
-            default => (string) $type,
+            default => (string)$type,
         };
     }
 

--- a/Classes/Service/AdmiralCloudService.php
+++ b/Classes/Service/AdmiralCloudService.php
@@ -84,7 +84,7 @@ class AdmiralCloudService implements SingletonInterface
         $this->storageRepository = $storageRepository;
     }
 
-    public function getMediaType(string $type): string
+    public function getMediaType(int|string $type): string
     {
         $fileType = FileType::tryFrom((int)$type);
 
@@ -93,7 +93,7 @@ class AdmiralCloudService implements SingletonInterface
             FileType::IMAGE => 'image',
             FileType::AUDIO => 'audio',
             FileType::VIDEO => 'video',
-            default => $type,
+            default => (string) $type,
         };
     }
 


### PR DESCRIPTION
In TYPO3 v13 was a change: $file->getProperty('type') now returns an int (the FileType backed-enum value) instead of a string, but the vendor method getMediaType(string $type) declares a strict string parameter — so PHP throws a TypeError.                                                                                                                                                  
                                                                                                                                                                                                        
The method already casts internally (FileType::tryFrom((int)$type)), so the minimal fix is to widen the parameter to accept int and string